### PR TITLE
Fix for CVE-2008-2266 and CVE-2004-2265

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -509,7 +509,7 @@ AC_CHECK_HEADERS(fcntl.h unistd.h memory.h malloc.h errno.h direct.h)
 AC_CHECK_HEADERS(io.h sys/time.h)
 AC_CHECK_FUNCS(getcwd popen gettimeofday isatty)
 
-AC_CHECK_FUNC(tempnam,,AC_DEFINE(tempnam,_FP_tempnam))
+AC_CHECK_FUNC([mkstemp],,[AC_MSG_ERROR([needs mkstemp])])
 
 #
 # strerror might be internally defined. this would cause a

--- a/uulib/configure.in
+++ b/uulib/configure.in
@@ -40,7 +40,7 @@ AC_CHECK_HEADERS(fcntl.h unistd.h memory.h malloc.h errno.h)
 AC_CHECK_HEADERS(io.h sys/time.h)
 AC_CHECK_FUNCS(gettimeofday)
 
-AC_CHECK_FUNC(tempnam,,AC_DEFINE(tempnam,_FP_tempnam))
+AC_CHECK_FUNC([mkstemp],,[AC_MSG_ERROR([needs mkstemp])])
 
 #
 # strerror might be internally defined. this would cause a


### PR DESCRIPTION
This is based on Nico Golde's Debian patch 037_CVE-2008-2266_symlink.diff ("Fixed a classical tempfile symlink attack vulnerability in libuu") with modifications:

* We require mkstemp, as it is standardized and widely available and we do not want to support insecure systems.
* Use sprintf instead of strcat/strcpy for simplicity.
* unlink temp file on fdopen failure also in uudeview.c.
* Remove x flag from fdopen calls, this is a leftover from the CAN-2004-2265 patch and has no effect. mkstemp automatically uses the O_EXCL flag, so the race issue CAN-2004-2265 is also fixed.

Debian bug: http://bugs.debian.org/480972