### PR TITLE
Enable tcltk on ci

### DIFF
--- a/.github/workflows/runci.yml
+++ b/.github/workflows/runci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential autoconf
+          sudo apt-get install -y build-essential autoconf tcl-dev tk-dev
       - name: Run CI
         run: |
           ./runci.sh

--- a/runci.sh
+++ b/runci.sh
@@ -1,33 +1,32 @@
 #!/bin/bash
 set -euo pipefail
 
+TKINC=/usr/include/tk/
+TCLINC=/usr/include/tcl/
+
 autoreconf -i
+
 
 # Test with ASAN / Address Sanitizer
 export ASAN_OPTIONS="abort_on_error=1"
-./configure CFLAGS="-fsanitize=address -U_FORTIFY_SOURCE" LDFLAGS="-fsanitize=address -U_FORTIFY_SOURCE"
+./configure CFLAGS="-fsanitize=address -U_FORTIFY_SOURCE" LDFLAGS="-fsanitize=address -U_FORTIFY_SOURCE" --enable-tk=$TKINC --enable-tcl=$TCLINC
 make clean
 make
 make check
+make xdeview
 
 # Test with clang and MSAN / Memory Sanitizer
 export MSAN_OPTIONS="abort_on_error=1"
-./configure CC=clang LD=clang CFLAGS="-fsanitize=memory -U_FORTIFY_SOURCE" LDFLAGS="-fsanitize=memory -U_FORTIFY_SOURCE"
+./configure CC=clang LD=clang CFLAGS="-fsanitize=memory -U_FORTIFY_SOURCE" LDFLAGS="-fsanitize=memory -U_FORTIFY_SOURCE" --enable-tk=$TKINC --enable-tcl=$TCLINC
 make clean
 make
 make check
+make xdeview
 
 # Test with clang and UBSAN / Undefined Behavior Sanitizer
 export UBSAN_OPTIONS="halt_on_error=1:abort_on_error=1"
-./configure CC=clang LD=clang CFLAGS="-fsanitize=undefined" LDFLAGS="-fsanitize=undefined"
+./configure CC=clang LD=clang CFLAGS="-fsanitize=undefined" LDFLAGS="-fsanitize=undefined" --enable-tk=$TKINC --enable-tcl=$TCLINC
 make clean
 make
 make check
-
-# Test with tcl/tk enabled
-# Install tcl/tk dev libraries
-sudo apt update
-sudo apt intall tcl-dev tk-dev
-./configure CC=clang LD=clang --enable-tk=/usr/include/tcl/ --enable-tcl=/usr/include/tk/
-make clean
 make xdeview

--- a/runci.sh
+++ b/runci.sh
@@ -23,3 +23,11 @@ export UBSAN_OPTIONS="halt_on_error=1:abort_on_error=1"
 make clean
 make
 make check
+
+# Test with tcl/tk enabled
+# Install tcl/tk dev libraries
+sudo apt update
+sudo apt intall tcl-dev tk-dev
+./configure CC=clang LD=clang --enable-tk=/usr/include/tcl/ --enable-tcl=/usr/include/tk/
+make clean
+make xdeview


### PR DESCRIPTION
### Related issues
- resolve #26 

### Change
- Install tcltk development libraries in the github runner and add the building of the `xdeview` application.